### PR TITLE
:gear: install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN cargo build --release
 FROM debian:10.6-slim
 
 RUN apt-get update -qq \
-  && apt-get install -y libpq-dev
+  && apt-get install -y libpq-dev \
+  && apt-get install -y --no-install-recommends ca-certificates
 
 WORKDIR /app
 


### PR DESCRIPTION
https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com を取得する時に下記のエラーが出た。
debian slim imageにはデフォルトではCA証明書が含まれていないようだ。

```
reqwest::Error { kind: Request, url: Url { scheme: "https", username: "", password: None, host: Some(Domain("www.googleapis.com")), port: None, path: "/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", query: None, fragment: None }, source: hyper::Error(Connect, Ssl(Error { code: ErrorCode(1), cause: Some(Ssl(ErrorStack([Error { code: 337047686, library: "SSL routines", function: "tls_process_server_certificate", reason: "certificate verify failed", file: "../ssl/statem/statem_clnt.c", line: 1915 }]))) }, X509VerifyResult { code: 20, error: "unable to get local issuer certificate" })) }
```