### PR TITLE
:gear: set Access-Control-Max-Age

### DIFF
--- a/src/cors.rs
+++ b/src/cors.rs
@@ -29,6 +29,7 @@ impl Fairing for CorsFairing {
 
         // NOTE: replace status code and body if not found
         if response.status() == Status::NotFound && request.method() == Method::Options {
+            response.set_header(Header::new("Access-Control-Max-Age", "86400"));
             response.set_status(Status::NoContent);
             response.set_sized_body(Cursor::new(""));
         }


### PR DESCRIPTION
推奨値がないか探したがわからなかった。
https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Access-Control-Max-Age
によると
- Firefox は24時間 (86400秒) 
- Chromium (v76 以降) は2時間 (7200秒)

とのことだったので、86400より長い値はセットしても意味なさそう。