### PR TITLE
Listen all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -qq \
 WORKDIR /app
 
 COPY --from=builder /app/target/release/rocket-template-app /usr/local/bin/
+COPY ./Rocket.toml /app
 COPY ./public /app/public
 
 CMD ROCKET_PORT=$PORT /usr/local/bin/rocket-template-app

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,2 +1,5 @@
 [debug]
 address = "127.0.0.1"
+
+[release]
+address = "0.0.0.0"


### PR DESCRIPTION
下記エラーでdeploy失敗
> Cloud Run error: Container failed to start. Failed to start and then listen on the port defined by the PORT environment variable. Logs for this revision might contain more information.