### PR TITLE
:sparkles: explicitly allow `Authorization` header

### DIFF
--- a/src/fairing/cors.rs
+++ b/src/fairing/cors.rs
@@ -25,7 +25,10 @@ impl Fairing for CorsFairing {
             "Access-Control-Allow-Methods",
             "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT",
         ));
-        response.set_header(Header::new("Access-Control-Allow-Headers", "*"));
+        response.set_header(Header::new(
+            "Access-Control-Allow-Headers",
+            "Authorization, *",
+        ));
         response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
 
         // NOTE: replace status code and body if not found


### PR DESCRIPTION
fix https://github.com/muk-ai/rocket-template/issues/64


> なお、 Authorization ヘッダーはワイルドカードで表すことができず、常に明示的に列挙する必要があります。

https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
これが原因？

これで気づけた。:bow:
https://stackoverflow.com/questions/68648135/access-control-max-age-not-working-with-authorization-header